### PR TITLE
Ds 2961

### DIFF
--- a/R/formats.R
+++ b/R/formats.R
@@ -1,5 +1,7 @@
 percent_preproc <- function(x) x * 100
 percent_postproc <- function(str, x)
+  paste0("\u200e", str, ifelse(is.finite(x), "%", ""))
+percent_postproc_noprefix <- function(str, x)
   paste0(str, ifelse(is.finite(x), "%", ""))
 accounting_postproc <- function(str, x)
   sprintf(ifelse(is.na(x) | x >= 0, "%s", "(%s)"),
@@ -10,9 +12,11 @@ accounting_postproc <- function(str, x)
 #' @param x a numeric vector.
 #' @param digits an integer to indicate the number of digits of the percentage string.
 #' @param format format type passed to \code{\link{formatC}}.
+#' @param as.output When true, a non-print left-to-right mark is prefixed
+#'    to the output string to align the text.
 #' @param ... additional parameters passed to \code{formattable}.
 #' @export
-percent <- function(x, digits, format = "f", ...)
+percent <- function(x, digits, format = "f", as.output = TRUE, ...)
   UseMethod("percent")
 
 #' @rdname percent
@@ -20,9 +24,10 @@ percent <- function(x, digits, format = "f", ...)
 #' @examples
 #' percent(rnorm(10, 0, 0.1))
 #' percent(rnorm(10, 0, 0.1), digits = 0)
-percent.default <- function(x, digits = 2L, format = "f", ...) {
+percent.default <- function(x, digits = 2L, format = "f", as.output = TRUE, ...) {
   formattable(as_numeric(x), format = format, digits = digits, ...,
-    preproc = "percent_preproc", postproc = "percent_postproc")
+    preproc = "percent_preproc",
+    postproc = if (as.output) "percent_postproc" else "percent_postproc_noprefix")
 }
 
 #' @rdname percent
@@ -30,12 +35,12 @@ percent.default <- function(x, digits = 2L, format = "f", ...) {
 #' @examples
 #' percent("0.5%")
 #' percent(c("15.5%", "25.12%", "73.5"))
-percent.character <- function(x, digits = NA, format = "f", ...) {
+percent.character <- function(x, digits = NA, format = "f", as.output = TRUE, ...) {
   valid <- grepl("^(.+)\\s*%$", x)
   pct <- gsub("^(.+)\\s*%$", "\\1", x)
   if (is.na(digits)) digits <- max(get_digits(x) - ifelse(valid, 0, 2))
   copy_dim(x, percent.default(as.numeric(pct) / ifelse(valid, 100, 1),
-    digits = digits, format = "f"))
+    digits = digits, format = "f", as.output = as.output))
 }
 
 #' Numeric vector showing pre-specific digits

--- a/R/formatter.R
+++ b/R/formatter.R
@@ -144,11 +144,10 @@ color_bar <- function(color = "lightgray", fun = "proportion", ...) {
     style = function(x) style(
       display = "inline-block",
       direction = "rtl",
-      "unicode-bidi" = "plaintext",
       "border-radius" = "4px",
       "padding-right" = "2px",
       "background-color" = csscolor(color),
-      width = percent(fun(as.numeric(x), ...))
+      width = percent(fun(abs(as.numeric(x)), ...), as.output = FALSE)
     ))
 }
 

--- a/man/percent.Rd
+++ b/man/percent.Rd
@@ -6,11 +6,11 @@
 \alias{percent.character}
 \title{Numeric vector with percentage representation}
 \usage{
-percent(x, digits, format = "f", ...)
+percent(x, digits, format = "f", as.output = TRUE, ...)
 
-\method{percent}{default}(x, digits = 2L, format = "f", ...)
+\method{percent}{default}(x, digits = 2L, format = "f", as.output = TRUE, ...)
 
-\method{percent}{character}(x, digits = NA, format = "f", ...)
+\method{percent}{character}(x, digits = NA, format = "f", as.output = TRUE, ...)
 }
 \arguments{
 \item{x}{a numeric vector.}
@@ -18,6 +18,9 @@ percent(x, digits, format = "f", ...)
 \item{digits}{an integer to indicate the number of digits of the percentage string.}
 
 \item{format}{format type passed to \code{\link{formatC}}.}
+
+\item{as.output}{When true, a non-print left-to-right mark is prefixed
+to the output string to align the text.}
 
 \item{...}{additional parameters passed to \code{formattable}.}
 }

--- a/tests/testthat/test-formats.R
+++ b/tests/testthat/test-formats.R
@@ -3,12 +3,14 @@ context("formats")
 test_that("percent", {
   expect_identical(format(percent(numeric())), character())
 
+add_lrm <- function(x) {paste0("\u200e", x)}
+
   data <- c(-0.05, 0.15, 0.252, 0.3003)
   obj <- percent(data)
   expect_is(obj, c("formattable", "numeric"))
-  expect_equal(format(obj), c("-5.00%", "15.00%", "25.20%", "30.03%"))
-  expect_equal(format(percent(data, digits = 0)), c("-5%", "15%", "25%", "30%"))
-  expect_equal(format(percent(obj, digits = 0)), c("-5%", "15%", "25%", "30%"))
+  expect_equal(format(obj), add_lrm(c("-5.00%", "15.00%", "25.20%", "30.03%")))
+  expect_equal(format(percent(data, digits = 0)), add_lrm(c("-5%", "15%", "25%", "30%")))
+  expect_equal(format(percent(obj, digits = 0)), add_lrm(c("-5%", "15%", "25%", "30%")))
   expect_warning(percent("a"), regexp = "NA")
   expect_equal(percent("1.00%"), percent(0.01))
   expect_equal(percent("1%"), percent(0.01, digits = 0L))
@@ -20,7 +22,7 @@ test_that("percent", {
   dim(data) <- c(2, 2)
   obj <- percent(data)
   expect_is(obj, c("formattable", "matrix"))
-  expect_equal(format(obj), matrix(c("-5.00%", "15.00%", "25.20%", "30.03%"), 2))
+  expect_equal(format(obj), matrix(add_lrm(c("-5.00%", "15.00%", "25.20%", "30.03%")), 2))
 
   # parse percent from matrix
   x <- matrix(c("0.5%", "1.5%", "10.2%", "3.8%"), 2,

--- a/tests/testthat/test-formattable.R
+++ b/tests/testthat/test-formattable.R
@@ -157,8 +157,8 @@ test_that("formattable.POSIXlt", {
 test_that("foramttable operators", {
   expect_equal(format(formattable(1:10) + 0.5), formatC(1:10 + 0.5))
   expect_equal(format(0.5 + formattable(1:10)), formatC(0.5 + 1:10))
-  expect_equal(format(percent(0.5) * 2), "100.00%")
-  expect_equal(format(2 * percent(0.5)), "100.00%")
+  expect_equal(format(percent(0.5) * 2), "\u200e100.00%")
+  expect_equal(format(2 * percent(0.5)), "\u200e100.00%")
 })
 
 test_that("formattable methods", {

--- a/tests/testthat/test-formatter.R
+++ b/tests/testthat/test-formatter.R
@@ -21,13 +21,13 @@ test_that("formatter", {
     c("<span style=\"font-weight: bold\">0.1</span>",
       "<span style=\"font-weight: bold\">0.2</span>"))
   expect_equal(bold(percent(c(0.1, 0.2))),
-    c("<span style=\"font-weight: bold\">10.00%</span>",
-      "<span style=\"font-weight: bold\">20.00%</span>"))
+    c("<span style=\"font-weight: bold\">\u200e10.00%</span>",
+      "<span style=\"font-weight: bold\">\u200e20.00%</span>"))
 
   bold_percent <- formatter("span", style = "font-weight: bold", percent)
   expect_equal(bold_percent(c(0.1, 0.2)),
-    c("<span style=\"font-weight: bold\">10.00%</span>",
-      "<span style=\"font-weight: bold\">20.00%</span>"))
+    c("<span style=\"font-weight: bold\">\u200e10.00%</span>",
+      "<span style=\"font-weight: bold\">\u200e20.00%</span>"))
 
   # dynamic scoping of formula
   expect_equal(local({
@@ -64,7 +64,7 @@ test_that("formatters", {
     "<span style=\"display: block; padding: 0 4px; border-radius: 4px; background-color: #ffdfe5\">0.2</span>",
     "<span style=\"display: block; padding: 0 4px; border-radius: 4px; background-color: #ffc0cb\">0.3</span>"
   ))
-  expect_equal(f(percent(x)), c(
+  expect_equal(f(percent(x, as.output = FALSE)), c(
     "<span style=\"display: block; padding: 0 4px; border-radius: 4px; background-color: #ffffff\">10.00%</span>",
     "<span style=\"display: block; padding: 0 4px; border-radius: 4px; background-color: #ffdfe5\">20.00%</span>",
     "<span style=\"display: block; padding: 0 4px; border-radius: 4px; background-color: #ffc0cb\">30.00%</span>"


### PR DESCRIPTION
This pull request is only fixing the right-alignment of percentages. I couldn't find an easier way to prepend all numeric cells.
Note that calls to `percent` in flipFormat need to be modified before we use this on the R server, but hoping to get some feedback these changes first.